### PR TITLE
Remove discretize warning

### DIFF
--- a/R/discretize.R
+++ b/R/discretize.R
@@ -75,7 +75,7 @@ discretize.formula <- function(x, y,
 
   if (all(!colClasses)) {
     stop("No columns of numeric classes!")
-  } else if (!all(colClasses)) {
+  } else if (any(!colClasses) && !all) {
     warning(paste("Columns with classes other than numeric will be skipped!\n",
                   "\n",
                   " Skipped columns:",
@@ -99,7 +99,7 @@ discretize.formula <- function(x, y,
   }
 
   if (!all) {
-    data <- data[, c(columnsToDiscretize, formula$y)]
+    data <- data[, c(formula$y, columnsToDiscretize)]
   }
 
   return(data)

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -75,11 +75,16 @@ discretize.formula <- function(x, y,
 
   if (all(!colClasses)) {
     stop("No columns of numeric classes!")
-  } else if (any(!colClasses) && !all) {
-    warning(paste("Columns with classes other than numeric will be skipped!\n",
-                  "\n",
-                  " Skipped columns:",
-                  paste(names(colClasses)[!colClasses], collapse = ", ")))
+  } else if (any(!colClasses)) {
+
+    if (!all) {
+      warning(
+        paste("Columns with classes other than numeric will be skipped!\n",
+              "\n",
+              " Skipped columns:",
+              paste(names(colClasses)[!colClasses], collapse = ", "))
+      )
+    }
 
     colClasses <- colClasses[colClasses]
   }

--- a/tests/testthat/test-discretize.R
+++ b/tests/testthat/test-discretize.R
@@ -42,7 +42,7 @@ test_that("Discretization - single NA (independent variable)", {
                                        data = iris)[, 1])
   Weka <- c(Weka[1:2], NA, tail(Weka, -2))
 
-  fs <- as.numeric(discretize(iris$Sepal.Length, iris$Species)[[1]])
+  fs <- as.numeric(discretize(iris$Sepal.Length, iris$Species)[[2]])
 
   expect_equal(Weka, fs)
 })
@@ -72,16 +72,16 @@ test_that("Discretization - equalsize - ordered.", {
   x <- 1:6
   y <- 1:6
 
-  d <- discretize(x, y, control = equalsizeControl(k = 2))[[1]]
+  d <- discretize(x, y, control = equalsizeControl(k = 2))[[2]]
   expect_equal(as.numeric(d), c(1, 1, 1, 2, 2, 2))
 
-  d <- discretize(x, y, control = equalsizeControl(k = 3))[[1]]
+  d <- discretize(x, y, control = equalsizeControl(k = 3))[[2]]
   expect_equal(as.numeric(d), c(1, 1, 2, 2, 3, 3))
 
-  d <- discretize(x, y, control = equalsizeControl(k = 4))[[1]]
+  d <- discretize(x, y, control = equalsizeControl(k = 4))[[2]]
   expect_equal(as.numeric(d), c(1, 1, 2, 2, 3, 4))
 
-  d <- discretize(x, y, control = equalsizeControl(k = 5))[[1]]
+  d <- discretize(x, y, control = equalsizeControl(k = 5))[[2]]
   expect_equal(as.numeric(d), c(1, 1, 2, 3, 4, 5))
 })
 
@@ -89,16 +89,16 @@ test_that("Discretization - equalsize - reverse order", {
   x <- 6:1
   y <- 1:6
 
-  d <- discretize(x, y, control = equalsizeControl(k = 2))[[1]]
+  d <- discretize(x, y, control = equalsizeControl(k = 2))[[2]]
   expect_equal(as.numeric(d), c(1, 1, 1, 2, 2, 2) %>% rev)
 
-  d <- discretize(x, y, control = equalsizeControl(k = 3))[[1]]
+  d <- discretize(x, y, control = equalsizeControl(k = 3))[[2]]
   expect_equal(as.numeric(d), c(1, 1, 2, 2, 3, 3) %>% rev)
 
-  d <- discretize(x, y, control = equalsizeControl(k = 4))[[1]]
+  d <- discretize(x, y, control = equalsizeControl(k = 4))[[2]]
   expect_equal(as.numeric(d), c(1, 1, 2, 2, 3, 4) %>% rev)
 
-  d <- discretize(x, y, control = equalsizeControl(k = 5))[[1]]
+  d <- discretize(x, y, control = equalsizeControl(k = 5))[[2]]
   expect_equal(as.numeric(d), c(1, 1, 2, 3, 4, 5) %>% rev)
 })
 
@@ -106,16 +106,16 @@ test_that("Discretization - equalsize - pseudo-random order", {
   x <- c(6, 4, 2, 3, 1, 5)
   y <- 1:6
 
-  d <- discretize(x, y, control = equalsizeControl(k = 2))[[1]]
+  d <- discretize(x, y, control = equalsizeControl(k = 2))[[2]]
   expect_equal(as.numeric(d), c(2, 2, 1, 1, 1, 2))
 
-  d <- discretize(x, y, control = equalsizeControl(k = 3))[[1]]
+  d <- discretize(x, y, control = equalsizeControl(k = 3))[[2]]
   expect_equal(as.numeric(d), c(3, 2, 1, 2, 1, 3))
 
-  d <- discretize(x, y, control = equalsizeControl(k = 4))[[1]]
+  d <- discretize(x, y, control = equalsizeControl(k = 4))[[2]]
   expect_equal(as.numeric(d), c(4, 2, 1, 2, 1, 3))
 
-  d <- discretize(x, y, control = equalsizeControl(k = 5))[[1]]
+  d <- discretize(x, y, control = equalsizeControl(k = 5))[[2]]
   expect_equal(as.numeric(d), c(5, 3, 1, 2, 1, 4))
 })
 
@@ -131,12 +131,12 @@ test_that("Zero split points", {
 test_that("Interfaces", {
   expect_equal(
     colnames(discretize(iris$Sepal.Length, iris[["Species"]])),
-    c("Sepal.Length", "Species")
+    c("Species", "Sepal.Length")
   )
 
   expect_equal(
     colnames(discretize(iris$Sepal.Length, iris[[5]])),
-    c("Sepal.Length", "Species")
+    c("Species", "Sepal.Length")
   )
 
   expect_equal(


### PR DESCRIPTION
This solves #60 issue. Moreover now always the first column of the discretized data frame is the one by which the others were discretized.

If this or the #56 branch is merged then some tests will need to be fixed in the other one before merging it.